### PR TITLE
automatic page context

### DIFF
--- a/TemplateDataProviders.module
+++ b/TemplateDataProviders.module
@@ -31,7 +31,7 @@ class TemplateDataProviders extends WireData implements Module, ConfigurableModu
      */
     protected $controllersPath = null;
 
-    
+
     public function __construct() {}
 
     /**
@@ -115,7 +115,7 @@ class TemplateDataProviders extends WireData implements Module, ConfigurableModu
      * @see http://processwire.com/apigen/class-Module.html
      */
     public function init() {
-        
+
         // Extracts the data providers path from the module config and
         // stores it in wire('config')->paths->dataproviders.
         $relativePath = $this->get('data_providers_path');
@@ -124,7 +124,7 @@ class TemplateDataProviders extends WireData implements Module, ConfigurableModu
         // add data providers path to wire config
         wire('config')->paths->dataproviders = realpath(wire('config')->paths->templates .
                                                         DIRECTORY_SEPARATOR . $relativePath);
-        
+
         // register \nw autoloader
         require_once(wire('config')->paths->TemplateDataProviders . '/nw/Autoloader.php');
         spl_autoload_register(array('\nw\Autoloader', 'autoload'));
@@ -156,7 +156,7 @@ class TemplateDataProviders extends WireData implements Module, ConfigurableModu
         // return if no page data provider defined for given page
         if (is_null($dataProvider)) return;
         $dataProvider->populate();
-        $event->replace=true; 
+        $event->replace=true;
     }
 
     /**
@@ -181,6 +181,7 @@ class TemplateDataProviders extends WireData implements Module, ConfigurableModu
         $context = array_slice($event->arguments(), 1, null, false);
 
         $dataProvider = \nw\DataProviders\Factory::get($chunkFile);
+        $dataProvider->page = $event->object;
         $dataProvider->setContext($context);
         $dataProvider->populate();
 


### PR DESCRIPTION
Summary:

add feature to have the `$page`, on which renderChunk is called on automatically be assigned to `ChunkDataProvider::page`

Sorry for the unclean diff, I have autostrip trailing whitespace enabled in Sublime Text, you could add only the one relevant line.

Now to the PR:

I have to admit, that I find the context stuff rather unintuitive and not too usable.

This PR makes the following possible:

``` PHP
foreach ($sections as $section) {
    $section->renderChunk('section.php');
    // instead of $page->renderChunk('section.php', $section)
    // which would also make it necessary to assign the context
    // to a variable of my choosing in the Provider manually,
    // see the chunk example in your readme
}
```

Since `renderChunk` is called on `$section`, the section will now automatically assigned to the Providers page var, so in my template `section.php`, I can use the `$page` var, which holds the $section it is called on.

```
$page->title; // it's the section's title
```

This makes the context stuff obsolete for me.

This does not break any of the context stuff.
